### PR TITLE
Add Celestial module for sunrise/sunset events

### DIFF
--- a/celestials/build.gradle.kts
+++ b/celestials/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    backendlibrary()
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            api(projects.server)
+            api(libs.kotlin.coroutines.core)
+            api(libs.kotlin.datetime)
+        }
+
+        jvmMain.dependencies {
+            implementation(libs.sunrisesunsetcalculator)
+        }
+
+        commonTest.dependencies {
+            implementation(projects.coreTesting)
+            implementation(projects.serverTesting)
+            implementation(libs.kotlin.test.core)
+            implementation(libs.kotlin.coroutines.test)
+        }
+    }
+}

--- a/celestials/src/commonMain/kotlin/usonia/celestials/CelestialAccess.kt
+++ b/celestials/src/commonMain/kotlin/usonia/celestials/CelestialAccess.kt
@@ -1,0 +1,14 @@
+package usonia.celestials
+
+import com.inkapplications.coroutines.ongoing.OngoingFlow
+
+/**
+ * Provides access to solar event data.
+ */
+interface CelestialAccess
+{
+    /**
+     * Get the latest schedule of solar events for the current site's location.
+     */
+    val localCelestials: OngoingFlow<UpcomingCelestials>
+}

--- a/celestials/src/commonMain/kotlin/usonia/celestials/Celestials.kt
+++ b/celestials/src/commonMain/kotlin/usonia/celestials/Celestials.kt
@@ -1,0 +1,15 @@
+package usonia.celestials
+
+import usonia.kotlin.datetime.ZonedDateTime
+import kotlin.time.Duration
+
+/**
+ * Snapshot of solar events for a single day.
+ */
+data class Celestials(
+    val daylight: ClosedRange<ZonedDateTime>,
+    val civilTwilight: ClosedRange<ZonedDateTime>,
+) {
+    val solarNoon: ZonedDateTime = daylight.start + ((daylight.endInclusive - daylight.start) / 2)
+    val dayLength: Duration = daylight.endInclusive - daylight.start
+}

--- a/celestials/src/commonMain/kotlin/usonia/celestials/UpcomingCelestials.kt
+++ b/celestials/src/commonMain/kotlin/usonia/celestials/UpcomingCelestials.kt
@@ -1,0 +1,65 @@
+package usonia.celestials
+
+import usonia.kotlin.datetime.ZonedDateTime
+
+/**
+ * A schedule of celestial events relevant to a given time.
+ *
+ * This is used to calculate the next/upcoming events, such as the next
+ * sunrise, in addition to the current day's events.
+ */
+data class UpcomingCelestials(
+    /**
+     * The timestamp that this schedule is based on.
+     *
+     * This is used to calculate the next relevant event for certain ranges.
+     */
+    val timestamp: ZonedDateTime,
+
+    /**
+     * Today's celestial evens
+     */
+    val today: Celestials,
+
+    /**
+     * Tomorrow's celestial events
+     */
+    val tomorrow: Celestials,
+) {
+    /**
+     * The start next morning's civil twilight.
+     */
+    val nextTwilightStart: ZonedDateTime = today.civilTwilight.start.unlessPassed(tomorrow.civilTwilight.start)
+
+    /**
+     * The next sunrise event to occur.
+     */
+    val nextSunrise: ZonedDateTime = today.daylight.start.unlessPassed(tomorrow.daylight.start)
+
+    /**
+     * The next sunset event to occur.
+     */
+    val nextSunset: ZonedDateTime = today.daylight.endInclusive.unlessPassed(tomorrow.daylight.endInclusive)
+
+    /**
+     * The end of the next evening's civil twilight.
+     */
+    val nextTwilightEnd: ZonedDateTime = today.civilTwilight.endInclusive.unlessPassed(tomorrow.civilTwilight.endInclusive)
+
+    /**
+     * The first event to occur in the schedule.
+     */
+    val firstEvent: ZonedDateTime = listOf(
+        nextSunrise,
+        nextTwilightStart,
+        nextTwilightEnd,
+        nextSunset,
+    ).min()
+
+    /**
+     * Use this date if not passed, otherwise use the provided date.
+     */
+    private fun ZonedDateTime.unlessPassed(otherwise: ZonedDateTime): ZonedDateTime {
+        return if (this < timestamp) otherwise else this
+    }
+}

--- a/celestials/src/commonTest/kotlin/usonia/celestials/CelestialsTest.kt
+++ b/celestials/src/commonTest/kotlin/usonia/celestials/CelestialsTest.kt
@@ -1,0 +1,27 @@
+package usonia.celestials
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.atTime
+import usonia.celestials.doubles.KnownCelestials.ZONE
+import usonia.kotlin.datetime.withZone
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+class CelestialsTest
+{
+    @Test
+    fun testCalculations()
+    {
+        val date = LocalDate(2024, 3, 17)
+        val celestials = Celestials(
+            daylight = date.atTime(LocalTime(7, 3, 0)).withZone(ZONE)..date.atTime(19, 5, 0).withZone(ZONE),
+            civilTwilight = date.atTime(6, 36, 0).withZone(ZONE)..date.atTime(19, 33, 0).withZone(ZONE),
+        )
+
+        assertEquals(12.hours + 2.minutes, celestials.dayLength)
+        assertEquals(date.atTime(13, 4, 0).withZone(ZONE), celestials.solarNoon)
+    }
+}

--- a/celestials/src/commonTest/kotlin/usonia/celestials/UpcomingCelestialsTest.kt
+++ b/celestials/src/commonTest/kotlin/usonia/celestials/UpcomingCelestialsTest.kt
@@ -1,0 +1,210 @@
+package usonia.celestials
+
+import kotlinx.datetime.atTime
+import usonia.celestials.doubles.KnownCelestials
+import usonia.kotlin.datetime.withZone
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.minutes
+
+class UpcomingCelestialsTest
+{
+    @Test
+    fun testEarliestSchedule()
+    {
+        val now = KnownCelestials.FIRST_DATE.atTime(1, 0).withZone(KnownCelestials.ZONE)
+
+        val upcoming = UpcomingCelestials(
+            timestamp = now,
+            today = KnownCelestials.FIRST,
+            tomorrow = KnownCelestials.SECOND,
+        )
+
+        assertEquals(
+            KnownCelestials.FIRST.civilTwilight.start,
+            upcoming.firstEvent,
+            "First Event is today's Twilight Start"
+        )
+        assertEquals(
+            KnownCelestials.FIRST.civilTwilight.start,
+            upcoming.nextTwilightStart,
+            "Next Twilight Start is today's Twilight Start"
+        )
+        assertEquals(
+            KnownCelestials.FIRST.daylight.start,
+            upcoming.nextSunrise,
+            "Next Sunrise is today's Sunrise"
+        )
+        assertEquals(
+            KnownCelestials.FIRST.daylight.endInclusive,
+            upcoming.nextSunset,
+            "Next Sunset is today's Sunset"
+        )
+        assertEquals(
+            KnownCelestials.FIRST.civilTwilight.endInclusive,
+            upcoming.nextTwilightEnd,
+            "Next Twilight End is today's Twilight End"
+        )
+    }
+
+    @Test
+    fun testAfterTwilightStart()
+    {
+        val now = KnownCelestials.FIRST_DATE
+            .atTime(KnownCelestials.FIRST.civilTwilight.start.plus(1.minutes).localDateTime.time)
+            .withZone(KnownCelestials.ZONE)
+
+        val upcoming = UpcomingCelestials(
+            timestamp = now,
+            today = KnownCelestials.FIRST,
+            tomorrow = KnownCelestials.SECOND,
+        )
+
+        assertEquals(
+            KnownCelestials.FIRST.daylight.start,
+            upcoming.firstEvent,
+            "First Event is today's Sunrise"
+        )
+        assertEquals(
+            KnownCelestials.SECOND.civilTwilight.start,
+            upcoming.nextTwilightStart,
+            "Next Twilight Start is tomorrow's Twilight Start"
+        )
+        assertEquals(
+            KnownCelestials.FIRST.daylight.start,
+            upcoming.nextSunrise,
+            "Next Sunrise is today's Sunrise"
+        )
+        assertEquals(
+            KnownCelestials.FIRST.daylight.endInclusive,
+            upcoming.nextSunset,
+            "Next Sunset is today's Sunset"
+        )
+        assertEquals(
+            KnownCelestials.FIRST.civilTwilight.endInclusive,
+            upcoming.nextTwilightEnd,
+            "Next Twilight End is today's Twilight End"
+        )
+    }
+
+    @Test
+    fun testAfterSunrise()
+    {
+        val now = KnownCelestials.FIRST_DATE
+            .atTime(KnownCelestials.FIRST.daylight.start.plus(1.minutes).localDateTime.time)
+            .withZone(KnownCelestials.ZONE)
+
+        val upcoming = UpcomingCelestials(
+            timestamp = now,
+            today = KnownCelestials.FIRST,
+            tomorrow = KnownCelestials.SECOND,
+        )
+
+        assertEquals(
+            KnownCelestials.FIRST.daylight.endInclusive,
+            upcoming.firstEvent,
+            "First Event is today's Sunset"
+        )
+        assertEquals(
+            KnownCelestials.SECOND.civilTwilight.start,
+            upcoming.nextTwilightStart,
+            "Next Twilight Start is tomorrow's Twilight Start"
+        )
+        assertEquals(
+            KnownCelestials.SECOND.daylight.start,
+            upcoming.nextSunrise,
+            "Next Sunrise is tomorrow's Sunrise"
+        )
+        assertEquals(
+            KnownCelestials.FIRST.daylight.endInclusive,
+            upcoming.nextSunset,
+            "Next Sunset is today's Sunset"
+        )
+        assertEquals(
+            KnownCelestials.FIRST.civilTwilight.endInclusive,
+            upcoming.nextTwilightEnd,
+            "Next Twilight End is today's Twilight End"
+        )
+    }
+
+    @Test
+    fun testAfterSunset()
+    {
+        val now = KnownCelestials.FIRST_DATE
+            .atTime(KnownCelestials.FIRST.daylight.endInclusive.plus(1.minutes).localDateTime.time)
+            .withZone(KnownCelestials.ZONE)
+
+        val upcoming = UpcomingCelestials(
+            timestamp = now,
+            today = KnownCelestials.FIRST,
+            tomorrow = KnownCelestials.SECOND,
+        )
+
+        assertEquals(
+            KnownCelestials.FIRST.civilTwilight.endInclusive,
+            upcoming.firstEvent,
+            "First Event is today's Twilight End"
+        )
+        assertEquals(
+            KnownCelestials.SECOND.civilTwilight.start,
+            upcoming.nextTwilightStart,
+            "Next Twilight Start is tomorrow's Twilight Start"
+        )
+        assertEquals(
+            KnownCelestials.SECOND.daylight.start,
+            upcoming.nextSunrise,
+            "Next Sunrise is tomorrow's Sunrise"
+        )
+        assertEquals(
+            KnownCelestials.SECOND.daylight.endInclusive,
+            upcoming.nextSunset,
+            "Next Sunset is tomorrow's Sunset"
+        )
+        assertEquals(
+            KnownCelestials.FIRST.civilTwilight.endInclusive,
+            upcoming.nextTwilightEnd,
+            "Next Twilight End is today's Twilight End"
+        )
+    }
+
+    @Test
+    fun testAfterTwilightEnd()
+    {
+        val now = KnownCelestials.FIRST_DATE
+            .atTime(KnownCelestials.FIRST.civilTwilight.endInclusive.plus(1.minutes).localDateTime.time)
+            .withZone(KnownCelestials.ZONE)
+
+        val upcoming = UpcomingCelestials(
+            timestamp = now,
+            today = KnownCelestials.FIRST,
+            tomorrow = KnownCelestials.SECOND,
+        )
+
+        assertEquals(
+            KnownCelestials.SECOND.civilTwilight.start,
+            upcoming.firstEvent,
+            "First Event is tomorrow's Twilight Start"
+        )
+        assertEquals(
+            KnownCelestials.SECOND.civilTwilight.start,
+            upcoming.nextTwilightStart,
+            "Next Twilight Start is tomorrow's Twilight Start"
+        )
+        assertEquals(
+            KnownCelestials.SECOND.daylight.start,
+            upcoming.nextSunrise,
+            "Next Sunrise is tomorrow's Sunrise"
+        )
+        assertEquals(
+            KnownCelestials.SECOND.daylight.endInclusive,
+            upcoming.nextSunset,
+            "Next Sunset is tomorrow's Sunset"
+        )
+        assertEquals(
+            KnownCelestials.SECOND.civilTwilight.endInclusive,
+            upcoming.nextTwilightEnd,
+            "Next Twilight End is tomorrow's Twilight End"
+        )
+    }
+}
+

--- a/celestials/src/commonTest/kotlin/usonia/celestials/doubles/KnownCelestials.kt
+++ b/celestials/src/commonTest/kotlin/usonia/celestials/doubles/KnownCelestials.kt
@@ -1,0 +1,27 @@
+package usonia.celestials.doubles
+
+import inkapplications.spondee.spatial.GeoCoordinates
+import inkapplications.spondee.spatial.latitude
+import inkapplications.spondee.spatial.longitude
+import kotlinx.datetime.*
+import usonia.celestials.Celestials
+import usonia.kotlin.datetime.withZone
+
+/**
+ * Fixed test data. A known sunrise/sunset schedule for a day in NYC.
+ */
+object KnownCelestials
+{
+    val LOCATION = GeoCoordinates(40.730610.latitude, (-73.935242).longitude)
+    val FIRST_DATE = LocalDate(2024, 3, 17)
+    val SECOND_DATE = LocalDate(2024, 3, 18)
+    val ZONE = TimeZone.of("America/New_York")
+    val FIRST = Celestials(
+        daylight = FIRST_DATE.atTime(LocalTime(7, 3, 0)).withZone(ZONE)..FIRST_DATE.atTime(19, 5, 0).withZone(ZONE),
+        civilTwilight = FIRST_DATE.atTime(6, 36, 0).withZone(ZONE)..FIRST_DATE.atTime(19, 33, 0).withZone(ZONE),
+    )
+    val SECOND = Celestials(
+        daylight = SECOND_DATE.atTime(7, 1, 0).withZone(ZONE)..SECOND_DATE.atTime(19, 7, 0).withZone(ZONE),
+        civilTwilight = SECOND_DATE.atTime(6, 34, 0).withZone(ZONE)..SECOND_DATE.atTime(19, 34, 0).withZone(ZONE),
+    )
+}

--- a/celestials/src/jvmMain/kotlin/usonia/celestials/JvmCelestialAccess.kt
+++ b/celestials/src/jvmMain/kotlin/usonia/celestials/JvmCelestialAccess.kt
@@ -1,0 +1,118 @@
+package usonia.celestials
+
+import com.inkapplications.coroutines.ongoing.*
+import com.luckycatlabs.sunrisesunset.SunriseSunsetCalculator
+import com.luckycatlabs.sunrisesunset.dto.Location
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
+import kotlinx.datetime.toJavaInstant
+import kotlinx.datetime.toJavaZoneId
+import kotlinx.datetime.TimeZone as KotlinTimeZone
+import kotlinx.datetime.toKotlinInstant
+import usonia.kotlin.datetime.ZonedClock
+import usonia.kotlin.datetime.ZonedDateTime
+import usonia.kotlin.datetime.current
+import usonia.kotlin.datetime.withZone
+import usonia.server.client.BackendClient
+import java.util.*
+
+/**
+ * Adapts the JVM sunrise/sunset calculator to provide celestial data.
+ */
+internal class JvmCelestialAccess(
+    usonia: BackendClient,
+    private val clock: ZonedClock,
+): CelestialAccess {
+    /**
+     * Latest location for the configured site.
+     */
+    private val location = usonia.site
+        .map { it.location }
+        .map { Location(it.latitude.asDecimal, it.longitude.asDecimal) }
+
+    override val localCelestials: OngoingFlow<UpcomingCelestials> = location
+        .map { location ->
+            SunriseSunsetCalculator(location, clock.timeZone.toJavaZoneId().id)
+        }
+        .flatMapLatest { calculator ->
+            updatingCelestialsFlow(calculator)
+        }
+
+    /**
+     * Get a JVM calendar instance from a ZonedClock for the current time.
+     */
+    private val ZonedClock.currentCalendar: Calendar
+        get() {
+            return Calendar.getInstance(TimeZone.getTimeZone(timeZone.toJavaZoneId()))
+                .apply {
+                    time = Date.from(now().toJavaInstant())
+                }
+        }
+
+    /**
+     * Create a flow of celestial data that updates when the data expires.
+     */
+    private fun updatingCelestialsFlow(calculator: SunriseSunsetCalculator): Flow<UpcomingCelestials>
+    {
+        return flow {
+            while (currentCoroutineContext().isActive) {
+                val celestials = currentCelestials(calculator)
+                emit(celestials)
+                delay(celestials.firstEvent - clock.now())
+            }
+        }
+    }
+
+    /**
+     * Create a schedule of two days of celestial events starting with today.
+     */
+    private fun currentCelestials(calculator: SunriseSunsetCalculator): UpcomingCelestials
+    {
+        val currentCalendar = clock.currentCalendar
+        val tomorrowCalendar = clock.currentCalendar.apply {
+            add(Calendar.DATE, 1)
+        }
+        val now = clock.current
+
+        return UpcomingCelestials(
+            timestamp = now,
+            today = celestialsForDay(calculator, currentCalendar),
+            tomorrow = celestialsForDay(calculator, tomorrowCalendar),
+        )
+    }
+
+    /**
+     * Create celestial data for the specified calendar date.
+     */
+    private fun celestialsForDay(calculator: SunriseSunsetCalculator, calendar: Calendar): Celestials
+    {
+        val sunrise = calculator.getOfficialSunriseCalendarForDate(calendar)
+        val sunset = calculator.getOfficialSunsetCalendarForDate(calendar)
+        val civilTwilightStart = calculator.getCivilSunriseCalendarForDate(calendar)
+        val civilTwilightEnd = calculator.getCivilSunsetCalendarForDate(calendar)
+
+        return Celestials(
+            daylight = sunrise.toZonedDateTime(
+                clock.timeZone
+            )..sunset.toZonedDateTime(
+                clock.timeZone
+            ),
+            civilTwilight = civilTwilightStart.toZonedDateTime(
+                clock.timeZone
+            )..civilTwilightEnd.toZonedDateTime(
+                clock.timeZone
+            ),
+        )
+    }
+
+    /**
+     * Convert a JVM calendar to a kotlinx ZonedDateTime.
+     */
+    private fun Calendar.toZonedDateTime(zone: KotlinTimeZone): ZonedDateTime
+    {
+        return toInstant().toKotlinInstant().withZone(zone)
+    }
+}

--- a/celestials/src/jvmTest/kotlin/usonia/celestials/JvmCelestialAccessTest.kt
+++ b/celestials/src/jvmTest/kotlin/usonia/celestials/JvmCelestialAccessTest.kt
@@ -1,0 +1,90 @@
+package usonia.celestials
+
+import com.inkapplications.coroutines.ongoing.collect
+import com.inkapplications.coroutines.ongoing.ongoingFlowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.*
+import usonia.celestials.doubles.KnownCelestials
+import usonia.core.state.ConfigurationAccess
+import usonia.core.state.ConfigurationAccessStub
+import usonia.foundation.FakeSite
+import usonia.kotlin.datetime.ZonedClock
+import usonia.server.DummyClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.minutes
+
+class JvmCelestialAccessTest
+{
+    private val backendClient = DummyClient.copy(
+        configurationAccess = object: ConfigurationAccess by ConfigurationAccessStub {
+            override val site = ongoingFlowOf(FakeSite.copy(
+                location = KnownCelestials.LOCATION,
+            ))
+        }
+    )
+
+    @Test
+    fun initialOutput()
+    {
+        val clock = object: ZonedClock {
+            override val timeZone: TimeZone = KnownCelestials.ZONE
+            override fun now(): Instant = KnownCelestials.FIRST_DATE.atTime(1, 0).toInstant(timeZone)
+        }
+        val celestialAccess = JvmCelestialAccess(
+            usonia  = backendClient,
+            clock = clock,
+        )
+
+        runTest {
+            val collected = mutableListOf<UpcomingCelestials>()
+            backgroundScope.launch {
+                celestialAccess.localCelestials.collect {
+                    collected.add(it)
+                }
+            }
+            runCurrent()
+
+            assertEquals(1, collected.size, "One update should be emitted")
+
+            assertEquals(KnownCelestials.FIRST, collected[0].today)
+            assertEquals(KnownCelestials.SECOND, collected[0].tomorrow)
+        }
+    }
+
+    @Test
+    fun afterEventPass()
+    {
+        val clock = object: ZonedClock {
+            override val timeZone: TimeZone = KnownCelestials.ZONE
+            override fun now(): Instant = KnownCelestials.FIRST_DATE.atTime(0, 0).toInstant(timeZone)
+        }
+        val celestialAccess = JvmCelestialAccess(
+            usonia  = backendClient,
+            clock = clock,
+        )
+
+        runTest {
+            val collected = mutableListOf<UpcomingCelestials>()
+            backgroundScope.launch {
+                celestialAccess.localCelestials.collect {
+                    collected.add(it)
+                }
+            }
+            runCurrent()
+
+            assertEquals(1, collected.size, "One update should be emitted")
+
+            advanceTimeBy(KnownCelestials.FIRST.civilTwilight.start - clock.now() + 1.minutes)
+
+            assertEquals(2, collected.size, "New update should be emitted after clock passes first event")
+            collected.forEach { schedule ->
+                assertEquals(KnownCelestials.FIRST, schedule.today)
+                assertEquals(KnownCelestials.SECOND, schedule.tomorrow)
+            }
+        }
+    }
+}

--- a/foundation/src/commonMain/kotlin/usonia/foundation/GeoCoordinatesSerializer.kt
+++ b/foundation/src/commonMain/kotlin/usonia/foundation/GeoCoordinatesSerializer.kt
@@ -1,0 +1,47 @@
+package usonia.foundation
+
+import inkapplications.spondee.spatial.GeoCoordinates
+import inkapplications.spondee.spatial.latitude
+import inkapplications.spondee.spatial.longitude
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+internal class GeoCoordinatesSerializer: KSerializer<GeoCoordinates>
+{
+    @Serializable
+    private data class Surrogate(
+        val latitude: Double,
+        val longitude: Double,
+    )
+
+    override val descriptor: SerialDescriptor = Surrogate.serializer().descriptor
+
+    override fun deserialize(decoder: Decoder): GeoCoordinates
+    {
+        val surrogate = Surrogate.serializer().deserialize(decoder)
+        return GeoCoordinates(
+            latitude = surrogate.latitude.latitude,
+            longitude = surrogate.longitude.longitude,
+        )
+    }
+
+    override fun serialize(encoder: Encoder, value: GeoCoordinates)
+    {
+        val surrogate = Surrogate(
+            latitude = value.latitude.asDecimal,
+            longitude = value.longitude.asDecimal,
+        )
+        Surrogate.serializer().serialize(encoder, surrogate)
+    }
+
+    object Defaults
+    {
+        val CENTRAL_US: GeoCoordinates = GeoCoordinates(
+            latitude = 39.8283.latitude,
+            longitude = (-98.5795).longitude,
+        )
+    }
+}

--- a/foundation/src/commonMain/kotlin/usonia/foundation/Site.kt
+++ b/foundation/src/commonMain/kotlin/usonia/foundation/Site.kt
@@ -1,5 +1,6 @@
 package usonia.foundation
 
+import inkapplications.spondee.spatial.GeoCoordinates
 import kotlinx.serialization.Serializable
 
 /**
@@ -13,6 +14,8 @@ import kotlinx.serialization.Serializable
 data class Site(
     val id: Identifier,
     val name: String,
+    @Serializable(with = GeoCoordinatesSerializer::class)
+    val location: GeoCoordinates = GeoCoordinatesSerializer.Defaults.CENTRAL_US,
     val users: Set<User> = emptySet(),
     val rooms: Set<Room> = emptySet(),
     val bridges: Set<Bridge> = emptySet(),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -164,6 +164,10 @@ module = "com.ionspin.kotlin:multiplatform-crypto-libsodium-bindings"
 version = "4.12"
 module = "junit:junit"
 
+[libraries.sunrisesunsetcalculator]
+version = "1.2"
+module = "com.luckycatlabs:SunriseSunsetCalculator"
+
 [bundles]
 watermelon-kotlin = [
     "watermelon-coroutines",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ rootProject.name = "usonia"
 
 include("archetypes")
 include("auth")
+include("celestials")
 include("cli")
 include("client-http")
 include("client-ktor")


### PR DESCRIPTION
This data is currently provided by the accuweather module, but I'm trying to move away from that. This also allows sunrise/sunset to be calculated locally in the event of a connection disruption.